### PR TITLE
FEATURE: Adds .json file writing/reading for wolfkrow_run_task tasks

### DIFF
--- a/src/wolfkrow/core/tasks/command_line.py
+++ b/src/wolfkrow/core/tasks/command_line.py
@@ -41,7 +41,7 @@ class CommandLine(SequenceTask):
     script = TaskAttribute(required=True, description="The Command to run on the command line.")
     args = TaskAttribute(required=True, attribute_type=list, description="The arguments to the command. Must be supplied as a list.")
 
-    def export_to_command_line(self, temp_dir=None, deadline=False):
+    def export_to_command_line(self, job_name, temp_dir=None, deadline=False):
         """ Overwrites the default behavior of this this method to just recreate 
             the command line script to run from the script and args attributes.
 

--- a/src/wolfkrow/core/tasks/nuke_render.py
+++ b/src/wolfkrow/core/tasks/nuke_render.py
@@ -15,14 +15,14 @@ from .task_exceptions import TaskValidationException
 from wolfkrow.core.engine.resolver import Resolver
 
 class NukeTask(Task):
-    def export_to_command_line(self, temp_dir=None, deadline=False):
+    def export_to_command_line(self, job_name, temp_dir=None, deadline=False):
         """ Will generate a `wolfkrow_run_task` command line command to run in 
             order to re-construct and run this task via command line. 
 
             Appends a '$' to the end of the command because nuke will try to accept
             the last arguments as a frame number/range.
         """
-        exported = super(NukeTask, self).export_to_command_line(deadline=deadline)
+        exported = super(NukeTask, self).export_to_command_line(job_name, temp_dir=temp_dir, deadline=deadline)
 
         updated_exported = []
         # Append a "$" to the end of the command so that nuke does not consume 

--- a/src/wolfkrow/core/tasks/sequence_task.py
+++ b/src/wolfkrow/core/tasks/sequence_task.py
@@ -90,12 +90,13 @@ class SequenceTask(Task):
 
         return value
 
-    def _generate_bash_script_contents(self, temp_dir=None, deadline=False):
+    def _generate_bash_script_contents(self, job_name, temp_dir=None, deadline=False):
         """ Overrides the default generate bash script method in order to tweak
         the bash scripts generated for use on deadline.
         """
-
-        bash_scripts = super(SequenceTask, self)._generate_bash_script_contents(temp_dir=temp_dir, deadline=deadline)
+        bash_scripts = super(SequenceTask, self)._generate_bash_script_contents(
+            job_name, temp_dir=temp_dir, deadline=deadline
+        )
 
         if deadline and self.start_frame is not None and self.end_frame is not None:
             for index, (task, bash_script) in enumerate(bash_scripts):
@@ -162,21 +163,22 @@ class SequenceTask(Task):
         self.name = name
         return tasks
 
+    def export_to_command_line(self, job_name, temp_dir=None, deadline=False):
+        """
+        Generates a `wolfkrow_run_task` command line command to run in order to
+        re-construct and run this task via command line.
 
-    def export_to_command_line(self, temp_dir=None, deadline=False):
-        """ Will generate a `wolfkrow_run_task` command line command to run in order to 
-            re-construct and run this task via command line. 
-
-            Args:
-                temp_dir (str): temp directory to write the stand alone python script to.
-                deadline (bool): whether or not to prepare this task for deadline.
+        Args:
+            temp_dir (str): temp directory to write the stand alone Python script to.
+            deadline (bool): whether or not to prepare this task for Deadline.
         """
 
         # We have a framed sequence task, so export the chunked tasks
         export_method_name = "export_to_command_line"
         export_method_args = {
+            "job_name": job_name,
             "temp_dir": temp_dir, 
-            "deadline": deadline
+            "deadline": deadline,
         }
         exported = self._export_sequence_task(
             export_method_name,

--- a/src/wolfkrow/core/tasks/task.py
+++ b/src/wolfkrow/core/tasks/task.py
@@ -10,6 +10,7 @@ import datetime
 import logging
 import os
 import six
+import textwrap
 import traceback
 
 from weakref import WeakKeyDictionary
@@ -365,52 +366,39 @@ class Task(with_metaclass(TaskType, object)):
 
         return file_path
 
-    def _command_line_sanitize_attribute(self, attribute_name, attribute_value, deadline=False):
-        """ Processes the attribute value to prepare it for use on the command line.
-
-            Does additional processing to prepare the attribute for use on deadline.
+    def _command_line_sanitize_attribute(
+        self, attribute_name, attribute_value, deadline=False
+    ):
         """
+        Processes the attribute value to prepare it for use on the command line.
 
-        # Ensure that these types are wrapped in quotes so they are interpreted 
-        # as a single argument.
-        if (isinstance(attribute_value, dict) or
-            isinstance(attribute_value, list) or
-            isinstance(attribute_value, set)):
-
-            attribute_value = repr(attribute_value)
-
-        # Sometimes the value here will be a unicode or byte string. If that
-        # is the case, then strip the "u" or "b" qualifier at the start of 
-        # the string output of repr.
-        # TODO: We should probably properly handle these special cases properly,
-        # but this seems to work... keep an eye on this.
-        attribute_value = repr(attribute_value)
-        try:
-            if attribute_value.startswith("u'") or attribute_value.startswith("b'"):
-                attribute_value = attribute_value[1:]
-        except Exception:
-            pass
-
+        Default implementation just returns the given value.
+        """
         return attribute_value
 
-    def export_to_command_line(self, temp_dir=None, deadline=False):
-        """ Will generate a `wolfkrow_run_task` command line command to run in order to 
-            re-construct and run this task via command line. 
-
-            Args:
-                temp_dir (str): temp directory to write the stand alone python script to.
-                deadline (bool): whether or not to prepare this task for deadline.
+    def export_to_command_line(self, job_name=None, temp_dir=None, deadline=False):
         """
+        Generates a `wolfkrow_run_task` command line command to run in order to
+        re-construct and run this task via command line.
 
+        Args:
+            job_name (str): The name of the job that this task is a part of.
+                Only used to generate the script's name.
+            temp_dir (str): Temp directory to write a BASH script to
+            deadline (bool): Whether to prepare this task for Deadline.
+        """
         if self.command_line_executable is None:
-            raise TaskException("WOLFKROW_DEFAULT_COMMAND_LINE_EXECUTABLE variable undefined and no executable specified.")
+            raise TaskException(
+                "WOLFKROW_DEFAULT_COMMAND_LINE_EXECUTABLE variable undefined "
+                "and no executable specified."
+            )
 
         if not self.temp_dir:
             self.temp_dir = temp_dir
 
-        arg_str = ""
+        task_args_dict = {}
 
-        for attribute_name, attribute_obj  in list(self.task_attributes.items()):
+        for attribute_name, attribute_obj in list(self.task_attributes.items()):
             if attribute_obj.serialize is False:
                 continue
 
@@ -418,49 +406,97 @@ class Task(with_metaclass(TaskType, object)):
             if value is None or value == attribute_obj.default_value:
                 continue
 
-            value = self._command_line_sanitize_attribute(attribute_name, value, deadline=deadline)
-
-            # Now put together the arg string
-            arg_str = "{arg_str} --{attribute_name} {value}".format(
-                arg_str=arg_str,
-                attribute_name=attribute_name,
-                value=value
+            sanitised_value = self._command_line_sanitize_attribute(
+                attribute_name, value, deadline=deadline
             )
 
+            task_args_dict[attribute_name] = sanitised_value
 
-        command = "{executable} {executable_args} --task_name {task_type} {task_args}".format(
-            executable=self.command_line_executable, 
-            executable_args= self.command_line_executable_args or "",
-            task_type=self.__class__.__name__, 
-            task_args=arg_str
+        task_args = []
+
+        if os.path.basename(self.command_line_executable).startswith("wolfkrow_run_task"):
+            # If the executable is Wolfkrow, then write all the args to a JSON
+            # file and pass the path in as a single arg
+            json_file_path = self._get_script_path(
+                extension="json", job_name=job_name, temp_dir=temp_dir
+            )
+
+            try:
+                with open(json_file_path, "w") as json_file:
+                    json.dump(task_args_dict, json_file, ensure_ascii=False, indent=4)
+
+            except Exception as exception:
+                raise TaskException(
+                    "Couldn't write args JSON file to path: %s - %s"
+                    % (json_file_path, exception)
+                )
+
+            start_frame = task_args_dict.get("start_frame")
+            end_frame = task_args_dict.get("end_frame")
+
+            # Include the start + end frames, as we want Deadline to be able to
+            # replace them for chunked jobs
+            if "start_frame" not in (None, "None"):
+                task_args.append("--start_frame \"%s\"" % start_frame)
+            if "end_frame" not in (None, "None"):
+                task_args.append("--end_frame \"%s\"" % end_frame)
+
+            task_args.append("--json_args_file \"%s\"" % json_file_path)
+
+        else:
+            # For other executables, pass the args in as "--key value" pairs
+            for attribute_name, attribute_value in task_args_dict.items():
+                task_args.append(
+                    "--{attribute_name} {value}".format(
+                        attribute_name=attribute_name,
+                        value=attribute_value
+                    )
+                )
+
+        task_args_string = " ".join(task_args)
+
+        command = (
+            "{executable} {executable_args} "
+            "--task_name {task_type} {task_args}".format(
+                executable=self.command_line_executable,
+                executable_args=self.command_line_executable_args or "",
+                task_type=self.__class__.__name__,
+                task_args=task_args_string,
+            )
         )
 
         return [(self, command)]
 
-    def _generate_bash_script_contents(self, temp_dir=None, deadline=False):
-        """ Generates the contents for a bash script export. Default implementation 
-        is just based off of the CommandLine export.
+    def _generate_bash_script_contents(self, job_name, temp_dir=None, deadline=False):
+        """
+        Generates the contents for a bash script export. Default implementation
+        is just based on the CommandLine export.
+
+        Args:
+            job_name (str): The name of the job that this task is a part of.
+                Only used to generate the script's name.
 
         Kwargs:
             temp_dir (str): temp directory to use for the command line export.
-            deadline (bool): whether or not to prepare this task for deadline.
+            deadline (bool): whether or not to prepare this task for Deadline.
         """
         command_line_export = self.export_to_command_line(
-            temp_dir=temp_dir, 
-            deadline=deadline
+            job_name=job_name, temp_dir=temp_dir, deadline=deadline
         )
 
         bash_scripts = []
-        bash_script_template ="""
-#!/usr/bin/env bash
+        bash_script_template = textwrap.dedent(
+            """
+            #!/usr/bin/env bash
 
-{command}
-"""
-        for export in command_line_export:
+            {command}
+            """
+        ).strip()
 
-            bash_script = bash_script_template.format(command=export[1])
-            bash_scripts.append((export[0], bash_script))
-        
+        for task, bash_command in command_line_export:
+            bash_script = bash_script_template.format(command=bash_command)
+            bash_scripts.append((task, bash_script))
+
         return bash_scripts
 
     def export_to_bash_script(self, job_name, temp_dir=None, deadline=False):

--- a/src/wolfkrow/core/tasks/task.py
+++ b/src/wolfkrow/core/tasks/task.py
@@ -436,9 +436,9 @@ class Task(with_metaclass(TaskType, object)):
 
             # Include the start + end frames, as we want Deadline to be able to
             # replace them for chunked jobs
-            if "start_frame" not in (None, "None"):
+            if start_frame not in (None, "None"):
                 task_args.append("--start_frame \"%s\"" % start_frame)
-            if "end_frame" not in (None, "None"):
+            if end_frame not in (None, "None"):
                 task_args.append("--end_frame \"%s\"" % end_frame)
 
             task_args.append("--json_args_file \"%s\"" % json_file_path)

--- a/src/wolfkrow/scripts/wolfkrow_run_task.py
+++ b/src/wolfkrow/scripts/wolfkrow_run_task.py
@@ -1,37 +1,107 @@
 #!/usr/bin/env python
-
+"""
+Module providing the main way to run Wolfkrow jobs from the command line.
+"""
 from builtins import zip
 from builtins import range
 import argparse
+import json
 import sys
 
 from wolfkrow.core.tasks import all_tasks
 
-def parse_args():
-    """ Parses the args passed into run_task.
 
-        Expects --task_name to be provided, and then an arbitrary amount of follow 
-        up arguments matching the form "--key value". Uses the additional arguments 
-        to construct a dictionary which is later used to instantiate a Task Object.
-
-        Returns:
-            args, task_args: Namespace containing the expected arguments, then a 
-                dictionary of all the additional arguments.
+class WolfkrowRunTaskException(Exception):
+    """
+    Exception for run task errors.
     """
 
-    parser = argparse.ArgumentParser(prog='wolfkrow_run_task')
-    parser.add_argument('--task_name', help="Class name of the task to run.")
+    pass
+
+
+def _print_and_raise(message):
+    """
+    Prints the given message and raises it as an exception.
+
+    Args:
+        message (str): The message to print + raise as an exception.
+    """
+    print("[ERROR] %s" % message)
+    raise WolfkrowRunTaskException(message)
+
+
+def parse_args():
+    """
+    Parses the args passed into run_task.
+
+    Requires a "--task_name" argument to specify the name of the task to run.
+
+    For preference, receives a "--json_args_file" argument specifying the path
+    to a JSON file containing the arguments for the task.
+
+    Alternatively supports receiving the task arguments as an arbitrary number
+    of arguments in the form "--key value".
+
+    In either case, these arguments are passed into a an instance of a Task
+    object of the type specified by "--task_name".
+
+    Returns:
+        args, task_args: Namespace containing the expected arguments, and a
+            dictionary of any other arguments.
+    """
+    parser = argparse.ArgumentParser(prog="wolfkrow_run_task")
+    parser.add_argument("--task_name", help="Class name of the task to run.")
+
+    parser.add_argument(
+        "--json_args_file",
+        help="JSON file containing all the args.",
+        required=False
+    )
+
     known, unknown = parser.parse_known_args()
 
-    # Assumes args passed in like "--key1 value1 --key2 value2 etc..." 
-    # Then strips the '--' from the keys to build a dictionary
+    # Load args from a JSON file
+    args_file_path = known.json_args_file
+    if args_file_path is not None:
+        if not os.path.isfile(args_file_path):
+            message = "No such JSON file: %s" % args_file_path
+            _print_and_raise(message)
+
+        try:
+            with open(args_file_path) as json_file:
+                task_args = json.load(json_file)
+
+        except Exception as exception:
+            message = (
+                "Couldn't load JSON file: %s - %s"
+                % (args_file_path, exception)
+            )
+            _print_and_raise(message)
+
+        if not isinstance(task_args, dict):
+            message = (
+                "JSON data read from %s is not a dictionary" % args_file_path
+            )
+            _print_and_raise(message)
+
+    # Overlay any extra args passed in like this:
+    #
+    #   "--key1 value1 --key2 value2 etc..."
     for index in range(len(unknown)):
-        if index % 2 == 0:
-            unknown[index] = unknown[index].lstrip('-')
-    task_args = dict(list(zip(unknown[:-1:2],unknown[1::2])))
+        if index % 2 == 0 and index < len(unknown) - 1:
+            key = unknown[index].lstrip("-")
+            value = unknown[index + 1]
+            task_args[key] = value
+
     return known, task_args
 
+
 def main():
+    """
+    Main entry point for the script.
+
+    Parses arguments, creates a Task instance + executes it.
+    """
     args, task_args = parse_args()
     task_class = all_tasks.get(args.task_name)
 
@@ -41,10 +111,12 @@ def main():
 
     # Use the args passed in to construct a Task Object
     task = task_class.from_dict(task_args)
-    
+
     # Execute the Task Object.
-    ret = task()
-    return ret
+    result = task()
+
+    return result
+
 
 if __name__ == '__main__':
     ret = main()

--- a/tests/test_export_sequence_task.py
+++ b/tests/test_export_sequence_task.py
@@ -43,7 +43,7 @@ class TestSequenceTask(WolfkrowTestCase):
 
         t1 = TestSequence(name="Task1", start_frame=10, end_frame=25, dependencies=[], replacements={}, command_line_executable="test")
 
-        exported = t1.export_to_command_line()
+        exported = t1.export_to_command_line("Test")
 
         # Count the amount of tasks there should be
         expected_export_count = int(math.ceil(float(t1.end_frame - t1.start_frame) / t1.chunk_size))


### PR DESCRIPTION
Certain jobs were failing with BASH syntax errors when fields had apostrophes in them - e.g. client sends with user comments in the args. This change puts all the args into a JSON file on disk, which can then be read back in by wolfkrow_run_task.