### PR TITLE
Reorder job attribute updates in task graph.

### DIFF
--- a/src/wolfkrow/core/engine/task_graph.py
+++ b/src/wolfkrow/core/engine/task_graph.py
@@ -351,18 +351,20 @@ class TaskGraph(object):
                 "JobDependencies": dependencies_str,
             }
 
-            # Now add the additional job attributes passed in, which may be required
-            # to run on the local deadline set up.
-            if additional_job_attributes:
-                job_attrs.update(additional_job_attributes)
-
-            # Finally, add the additional job attributes from the configuration file.
+            # Add the additional job attributes from the configuration file.
             additional_job_attrs = self._get_additional_job_attrs(
                 replacements=task.task.replacements,
                 sgtk=task.task.sgtk,
                 task_type=task.task.__class__.__name__
             )
             job_attrs.update(additional_job_attrs)
+
+            # Finally add the additional job attributes passed in, which may be required
+            # to run on the local deadline set up.
+            # Add these attributes after those from the configuration file,
+            # as they may override existing attributes from the file.
+            if additional_job_attributes:
+                job_attrs.update(additional_job_attributes)
 
             # If the task has a start_frame, end_frame, and chunk_size, then add these attributes to the deadline job.
             if (hasattr(task.task, "chunkable") and task.task.chunkable is True and


### PR DESCRIPTION
Moved additional job attributes from configuration file to be updated before the explicitly passed-in attributes. This ensures that passed-in attributes can override those from the configuration file, maintaining correct precedence.

For example:
The extra_job_attributes has `UserName: "$USER"`. In scenarios where the app is running on a server instead of the user machine we need to pass in an override. If we pass UserName as an override it will get overridden by attrs in the config file. 