### PR TITLE
Add new Deadline Plugin "WolfkrowTask" as custom plugin to execute Tasks apposed to relying on CommandLine Plugin

### DIFF
--- a/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.options
+++ b/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.options
@@ -1,0 +1,35 @@
+
+[Executable]
+Type=string
+Label=Executable
+Description=Full path to the Python interpreter.
+Default=
+
+[ExecutableArgs]
+Type=string
+Label=Executable Args
+Description=Args
+
+[StartFrame]
+Type=int
+Label=Start frame
+Description=Frame to start processing from.
+
+[EndFrame]
+Type=int
+Label=End Frame
+Description=Frame to finish processing at.
+
+[TaskName]
+Type=string
+Label=Task Name
+Description=Name of the wolfkrow task to run.
+
+[JsonArgsFile]
+Type=string
+Label=JSON Args File
+Description=Path to the JSON arguments file for the task.
+
+[AdditionalArgs]
+Type=string
+Label=Additional args to pass ta the end of the command.

--- a/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.param
+++ b/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.param
@@ -1,0 +1,4 @@
+[WolfkrowTask]
+Type=string
+Label=Wolfkrow Task Runner
+Description=Runs a wolfkrow task with a Python script.

--- a/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.py
+++ b/deadline/custom/plugins/WolfkrowTask/WolfkrowTask.py
@@ -1,0 +1,171 @@
+
+import re
+
+from Deadline.Plugins import DeadlinePlugin, PluginType
+from FranticX.Processes import ManagedProcess
+
+def GetDeadlinePlugin():
+    return WolfkrowTask()
+
+def CleanupDeadlinePlugin(plugin):
+    plugin.cleanup()
+
+class WolfkrowTask(DeadlinePlugin):
+    def __init__(self):
+        super().__init__()
+
+        self.InitializeProcessCallback += self.initialize_process
+        self.RenderTasksCallback += self.render_tasks
+
+        self.ManagedProcess = None
+
+    def cleanup(self):
+        self.CleanupProcess()
+
+        del self.InitializeProcessCallback
+
+        if self.ManagedProcess:
+            self.ManagedProcess.Cleanup()
+            del self.ManagedProcess
+
+    def initialize_process(self):
+        self.PluginType = PluginType.Advanced
+        self.StdoutHandling = True
+        self.UseProcessTree = True
+
+
+    def render_tasks(self):
+        executable_args = self.GetPluginInfoEntry("ExecutableArgs")
+        if executable_args:
+            executable_args = [executable_args]
+
+        additional_args = self.GetPluginInfoEntry("AdditionalArgs")
+        if additional_args:
+            additional_args = [additional_args]
+        
+        executable = self.GetPluginInfoEntry("Executable")
+
+        task_name = self.GetPluginInfoEntry("TaskName")
+
+        json_args_file = self.GetPluginInfoEntry("JsonArgsFile")
+
+        # Get the start and end frame configured for this plugin.
+        start_frame = self.GetPluginInfoEntry("StartFrame")
+        end_frame = self.GetPluginInfoEntry("EndFrame")
+
+        # For job chunking, the start and end frame above, will be <START_FRAME> and <END_FRAME>.
+        if isinstance(start_frame, str):
+            start_frame = re.sub( r"<(?i)STARTFRAME>", str(self.GetStartFrame()), start_frame)
+        
+        if isinstance(end_frame, str):
+            end_frame = re.sub( r"<(?i)ENDFRAME>", str(self.GetEndFrame()), end_frame)
+
+        # Build the command
+        command_bits = []
+
+        # Executble args must go first so they are passed to the executable directly (typically Python)
+        if executable_args:
+            command_bits += executable_args
+
+        # Next, we add any frame range information.
+        # NOTE: It is important that the start and end frame args are not the last
+        #   args. This is because sometimes the executable will be Nuke, and Nuke
+        #   consumes any numbers at the the end of the command line as it's own
+        #   internal arguments.
+        if start_frame is not None and end_frame is not None:
+            command_bits += [
+                "--start_frame", str(start_frame),
+                "--end_frame", str(end_frame), 
+            ]
+
+        # Next, add the name of the Task to use for execution
+        if task_name:
+            command_bits += [
+                "--task_name", task_name
+            ]
+
+        # Next, we add the main json args file.
+        if json_args_file:
+            command_bits += [
+                "--json_args_file", json_args_file
+            ]
+
+        # And Finally, allow any other arbitrary args. This gives us enough flexibility 
+        # to bypass a normal python executable, and the wolfkrow_run_task script 
+        # if needed, and just call some other executable with custom args.
+        if additional_args:
+            command_bits += additional_args
+
+        print("Executing command:")
+        print(" ".join([executable] + command_bits))
+
+        self.managed_process = ShellManagedProcess(self, executable, command_bits)
+        self.RunManagedProcess(self.managed_process)
+
+        if self.managed_process.exit_code != 0:
+            self.FailRender(f"Wolfkrow Task exited with non-zero exit code: {self.managed_process.exit_code}")
+
+class ShellManagedProcess( ManagedProcess ):
+    """ Provides a simple Managed process with progress handling which will be 
+    initialized and executed by the WolfkrowTask deadline plugin.
+    """
+    
+    def __init__( self, deadlinePlugin, executable, arguments):
+        super().__init__()
+
+        self.deadlinePlugin = deadlinePlugin
+        self.executable = executable
+        self.arguments = arguments
+        self.exit_code = -1
+
+        # Regex uesd to parse the output logs of the wolfkrow task to track the progress.
+        self.progress_regex = r".*Progress: (\d+([.]\d+)?)%.*"
+
+        self.InitializeProcessCallback += self.initialize_process
+        self.RenderExecutableCallback += self.render_executable
+        self.RenderArgumentCallback += self.render_arguments
+        self.CheckExitCodeCallback += self.check_exit_code
+
+    def Cleanup( self ):
+        for stdoutHandler in self.StdoutHandlers:
+            del stdoutHandler.HandleCallback
+
+        del self.InitializeProcessCallback
+        del self.RenderExecutableCallback
+        del self.RenderArgumentCallback
+        del self.CheckExitCodeCallback
+    
+    def initialize_process(self):
+        self.PopupHandling = True
+        self.StdoutHandling = True
+        self.HideDosWindow = True
+        # Ensure child processes are killed and the parent process is terminated on exit
+        self.UseProcessTree = True
+        self.TerminateOnExit = True
+
+        self.AddStdoutHandlerCallback(self.progress_regex).HandleCallback += self.handle_progress
+
+    def render_executable(self):
+        return self.executable
+
+    def render_arguments(self):
+        return " ".join(self.arguments)
+
+    def check_exit_code(self, exit_code):
+        # Seems to be a bug in Nuke 16 which is introducing this exit code during Nuke Shutdown. 
+        # Just Ignore it and we should be fine.
+        if exit_code == -1073740940:
+            self.exit_code = 0
+            self.deadlinePlugin.LogInfo( "Ignoring Nuke 16.0 Shutdown Exit Code -1073740940" )
+        else:
+            self.exit_code = exit_code
+
+    def handle_progress(self):
+        """ Progress handler for Wolfkrow Tasks.
+
+        Similar to the default CommandLine executable, it expects a log like "Progress: 56%"
+        And then it will extract the % value, and set the deadline tasks progress 
+        on Deadline.
+        """
+        progress = float(self.GetRegexMatch(1))
+        self.deadlinePlugin.SetProgress(progress)

--- a/src/wolfkrow/core/engine/task_export.py
+++ b/src/wolfkrow/core/engine/task_export.py
@@ -2,11 +2,25 @@
 
 
 class TaskExport(object):
-    def __init__(self, task, executable, executable_args=None, args=None):
+    def __init__(self, 
+        task, 
+        executable, 
+        executable_args=None, 
+        json_args_file=None,
+        start_frame=None, 
+        end_frame=None, 
+        args=None
+    ):
         self.task = task
         self.executable = executable
         self.executable_args = executable_args
-        self.task_args = args
+
+        self.json_args_file = json_args_file
+
+        self.start_frame = start_frame
+        self.end_frame = end_frame
+
+        self.additional_args = args
 
         self.deadline_id = None
 
@@ -17,7 +31,9 @@ class TaskExport(object):
         Returns:
             str: The complete command
         """
-        return self.executable + ' ' + self.args
+
+        command_bits = self.as_list()
+        return " ".join(command_bits)
 
     @property
     def args(self):
@@ -26,27 +42,43 @@ class TaskExport(object):
         Returns:
             str: The complete argument string
         """
-        args = ""
-        if self.executable_args:
-            executable_args = " ".join(self.executable_args)
-            args += executable_args + " "
-        if self.task_args:
-            args += self.task_args
 
-        return args
+        command_bits = self.as_list()
+        return " ".join(command_bits[1:])
 
     def as_list(self):
-        """ Returns the command as a list rather than a string. """
+        """ Returns the command as a list suitable for subprocess calls."""
 
-        args = []
+        command_bits = []
 
-        args.append(self.executable)
+        # Add the main executable first.
+        command_bits.append(self.executable)
 
+        # Executble args must go first so they are passed to the executable directly (typically Python)
         if self.executable_args:
-            args.extend(self.executable_args)
-            
-        # TODO: This will break if an argument has a space in it.
-        if self.task_args:
-            args.extend(self.task_args.split())
+            command_bits += self.executable_args
 
-        return args
+        # Next, we add any frame range information.
+        # NOTE: It is important that the start and end frame args are not the last
+        #   args. This is because sometimes the executable will be Nuke, and Nuke
+        #   consumes any numbers at the the end of the command line as it's own
+        #   internal arguments.
+        if self.start_frame is not None and self.end_frame is not None:
+            command_bits += [
+                "--start_frame", str(self.start_frame),
+                "--end_frame", str(self.end_frame), 
+            ]
+
+        # Next, we add the main json args file.
+        if self.json_args_file:
+            command_bits += [
+                "--json_args_file", self.json_args_file
+            ]
+
+        # And Finally, allow any other arbitrary args. This gives us enough flexibility 
+        # to bypass a normal python executable, and the wolfkrow_run_task script 
+        # if needed, and just call some other executable with custom args.
+        if self.additional_args:
+            command_bits += self.additional_args
+
+        return command_bits

--- a/src/wolfkrow/core/engine/task_graph.py
+++ b/src/wolfkrow/core/engine/task_graph.py
@@ -361,7 +361,7 @@ class TaskGraph(object):
             job_attrs = {
                 "Name": task_export.task.full_name,
                 "BatchName": batch_name,
-                "Plugin": "CommandLine",
+                "Plugin": "WolfkrowTask",
                 "JobDependencies": dependencies_str,
             }
 
@@ -439,8 +439,13 @@ class TaskGraph(object):
                 var_index += 1
 
             plugin_attrs = {
-                "Executable": task.executable,
-                "Arguments": task.args,
+                "TaskName": task.task.__class__.__name__,
+                "Executable": task_export.executable,
+                "ExecutableArgs": " ".join(task_export.executable_args),
+                "JsonArgsFile": task.json_args_file,
+                "StartFrame": task_export.start_frame,
+                "EndFrame": task_export.end_frame,
+                "AdditionalArgs": " ".join(task_export.additional_args),
             }
 
             job = deadline.Jobs.SubmitJob(job_attrs, plugin_attrs)

--- a/src/wolfkrow/core/tasks/__init__.py
+++ b/src/wolfkrow/core/tasks/__init__.py
@@ -18,10 +18,10 @@ from . import *
 # Search direcotries found in the WOLFKROW_TASK_SEARCH_PATHS.
 # Note: Tasks defined more than once will overwrite and previous definitions found.
 
-PATH_SEP = ":"
+import os
+PATH_SEP = os.path.pathsep
 
 import imp
-import os
 search_paths = os.environ.get('WOLFKROW_TASK_SEARCH_PATHS')
 if search_paths:
     for item in search_paths.split(PATH_SEP):

--- a/src/wolfkrow/core/tasks/nuke_render.py
+++ b/src/wolfkrow/core/tasks/nuke_render.py
@@ -16,26 +16,6 @@ from .task_exceptions import TaskValidationException
 from wolfkrow.core.engine.resolver import Resolver
 
 class NukeTask(Task):
-    def export_to_command_line(self, job_name, temp_dir=None, deadline=False, export_json=False):
-        """ Will generate a `wolfkrow_run_task` command line command to run in 
-            order to re-construct and run this task via command line. 
-
-            Appends a '$' to the end of the command because nuke will try to accept
-            the last arguments as a frame number/range.
-        """
-        exported = super(NukeTask, self).export_to_command_line(
-            job_name,
-            temp_dir=temp_dir,
-            deadline=deadline,
-        )
-
-        # Append a "$" to the end of the command so that nuke does not consume 
-        # the last argument as a frame number/range.
-        for export in exported:
-            args = "{} $".format(export.task_args)
-            export.task_args = args
-        return exported
-
     def _command_line_sanitize_attribute(
         self, attribute_name, attribute_value, deadline=False
     ):
@@ -640,7 +620,7 @@ writing exr, sgi, targa, or tiff files. Each file type has its own options. See 
         # settings on the write node when saving the script. This error only occurs 
         # when running nuke in terminal mode, and currently seems to only affect 
         # the codec profile knobs (More testing is required for specific knobs 
-        # effected).
+        # affected).
         # To get around this, we are going to open the nuke script after saving 
         # as a text file, then use some regex magic to find the Write node and 
         # confirm it's correct - If not, we will print a warning (To assist with 

--- a/src/wolfkrow/core/tasks/task.py
+++ b/src/wolfkrow/core/tasks/task.py
@@ -474,6 +474,9 @@ class Task(with_metaclass(TaskType, object)):
             task_args_dict[attribute_name] = sanitised_value
 
         task_args = []
+        json_file_path = None
+        start_frame = None
+        end_frame = None
 
         if export_json:
             # If the executable is Wolfkrow, then write all the args to a JSON
@@ -495,16 +498,8 @@ class Task(with_metaclass(TaskType, object)):
             start_frame = task_args_dict.get("start_frame")
             end_frame = task_args_dict.get("end_frame")
 
-            # Include the start + end frames, as we want Deadline to be able to
-            # replace them for chunked jobs
-            if start_frame not in (None, "None"):
-                task_args.append("--start_frame \"%s\"" % start_frame)
-            if end_frame not in (None, "None"):
-                task_args.append("--end_frame \"%s\"" % end_frame)
-
-            task_args.append("--json_args_file \"%s\"" % json_file_path)
-
         else:
+            task_args = []
             # For other executables, pass the args in as "--key value" pairs
             for attribute_name, attribute_value in task_args_dict.items():
                 task_args.append(
@@ -513,16 +508,15 @@ class Task(with_metaclass(TaskType, object)):
                         value=attribute_value
                     )
                 )
-
-        # Now put together the arg string
-        arg_str = "--task_name {task_name} ".format(task_name=self.__class__.__name__)
-        arg_str += " ".join(task_args)
         
         exported_task = TaskExport(
-            self, 
+            self,
             executable=self.command_line_executable, 
             executable_args=self.command_line_executable_args,
-            args=arg_str
+            json_args_file=json_file_path,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            args=task_args
         )
 
         return [exported_task]


### PR DESCRIPTION
The CommandLine Plugin forces us to work in a specific way, and doesn't seem to appropriately handle the logs, so I've implemented a new WolfkrowTask Plugin in Deadline accepts the arguments to WolfkrowRunTask.py as parameters, and then re-constructs the command on the farm.

The main purpose of this command is to allow deadline tasks to display % completion by parsing `Progress: 56%` style logs.

NOTE: While not the purpose of this change, it does lay the framework to help prevent arbitrary code execution by not allowing an arbitrary executable, with arbitrary arguments being executed because it forces the format of the WolfkrowRunTask command.